### PR TITLE
Partially hidden toolbars can now be scrolled with the mouse wheel

### DIFF
--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -630,7 +630,9 @@ EditorPanel::EditorPanel (FilePanel* filePanel)
     beforeAfterBox->set_name ("BeforeAfterContainer");
     beforeAfterBox->pack_start (*afterBox);
 
-    editbox->pack_start (*toolBarPanel, Gtk::PACK_SHRINK, 2);
+    MyScrolledToolbar *stb1 = Gtk::manage(new MyScrolledToolbar());
+    stb1->add(*toolBarPanel);
+    editbox->pack_start (*stb1, Gtk::PACK_SHRINK, 2);
     editbox->pack_start (*beforeAfterBox);
 
     // build right side panel
@@ -763,7 +765,10 @@ EditorPanel::EditorPanel (FilePanel* filePanel)
     iops->attach_next_to (*tbShowHideSidePanels, Gtk::POS_RIGHT, 1, 1);
     iops->attach_next_to (*tbRightPanel_1, Gtk::POS_RIGHT, 1, 1);
 
-    editbox->pack_start (*iops, Gtk::PACK_SHRINK, 0);
+    MyScrolledToolbar *stb2 = Gtk::manage(new MyScrolledToolbar());
+    stb2->add(*iops);
+
+    editbox->pack_start (*stb2, Gtk::PACK_SHRINK, 0);
     editbox->show_all ();
 
     // build screen

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -48,6 +48,7 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
     listener(nullptr),
     fslistener(nullptr),
     iatlistener(nullptr),
+    hbToolBar1STB(nullptr),
     hasValidCurrentEFS(false),
     filterPanel(nullptr),
     exportPanel(nullptr),
@@ -127,13 +128,17 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
 
     // if NOT a single row toolbar
     if (!options.FileBrowserToolbarSingleRow) {
-        pack_start (*hbToolBar1, Gtk::PACK_SHRINK, 0);
+        hbToolBar1STB = Gtk::manage(new MyScrolledToolbar());
+        hbToolBar1STB->add(*hbToolBar1);
+        pack_start (*hbToolBar1STB, Gtk::PACK_SHRINK, 0);
     }
 
     // setup button bar
     buttonBar = Gtk::manage( new Gtk::HBox () );
     buttonBar->set_name ("ToolBarPanelFileBrowser");
-    pack_start (*buttonBar, Gtk::PACK_SHRINK);
+    MyScrolledToolbar *stb = Gtk::manage(new MyScrolledToolbar());
+    stb->add(*buttonBar);
+    pack_start (*stb, Gtk::PACK_SHRINK);
 
     tbLeftPanel_1 = new Gtk::ToggleButton ();
     iLeftPanel_1_Show = new RTImage("panel-to-right.png");
@@ -692,6 +697,9 @@ void FileCatalog::enableTabMode(bool enable)
     } else {
         buttonBar->show();
         hbToolBar1->show();
+        if (hbToolBar1STB) {
+            hbToolBar1STB->show();
+        }
         exifInfo->set_active( options.showFileNames );
     }
 
@@ -910,8 +918,8 @@ void FileCatalog::refreshHeight ()
         newHeight = h;
     }
 
-    if (hbToolBar1->is_visible() && !options.FileBrowserToolbarSingleRow) {
-        newHeight += hbToolBar1->get_height();
+    if (hbToolBar1STB && hbToolBar1STB->is_visible()) {
+        newHeight += hbToolBar1STB->get_height();
     }
 
     if (buttonBar->is_visible()) {
@@ -2039,17 +2047,20 @@ void FileCatalog::updateFBQueryTB (bool singleRow)
     hbToolBar1->reference();
 
     if (singleRow) {
-        bool removed = removeIfThere(this, hbToolBar1, false);
-
-        if (removed) {
+        if (hbToolBar1STB) {
+            hbToolBar1STB->remove_with_viewport();
+            removeIfThere(this, hbToolBar1STB, false);
             buttonBar->pack_start(*hbToolBar1, Gtk::PACK_EXPAND_WIDGET, 0);
+            hbToolBar1STB = nullptr;
         }
     } else {
-        bool removed = removeIfThere(buttonBar, hbToolBar1, false);
-
-        if (removed) {
-            pack_start(*hbToolBar1, Gtk::PACK_SHRINK, 0);
-            reorder_child(*hbToolBar1, 0);
+        if (!hbToolBar1STB) {
+            removeIfThere(buttonBar, hbToolBar1, false);
+            hbToolBar1STB = Gtk::manage(new MyScrolledToolbar());
+            hbToolBar1STB->add(*hbToolBar1);
+            hbToolBar1STB->show();
+            pack_start (*hbToolBar1STB, Gtk::PACK_SHRINK, 0);
+            reorder_child(*hbToolBar1STB, 0);
         }
     }
 
@@ -2592,7 +2603,7 @@ bool FileCatalog::handleShortcutKey (GdkEventKey* event)
 void FileCatalog::showToolBar()
 {
     if (!options.FileBrowserToolbarSingleRow) {
-        hbToolBar1->show();
+        hbToolBar1STB->show();
     }
 
     buttonBar->show();
@@ -2601,7 +2612,7 @@ void FileCatalog::showToolBar()
 void FileCatalog::hideToolBar()
 {
     if (!options.FileBrowserToolbarSingleRow) {
-        hbToolBar1->hide();
+        hbToolBar1STB->hide();
     }
 
     buttonBar->hide();

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -73,6 +73,7 @@ private:
 
     Gtk::HBox* buttonBar;
     Gtk::HBox* hbToolBar1;
+    MyScrolledToolbar* hbToolBar1STB;
 
     Gtk::HBox* fltrRankbox;
     Gtk::HBox* fltrLabelbox;

--- a/rtgui/guiutils.cc
+++ b/rtgui/guiutils.cc
@@ -955,7 +955,7 @@ bool MyScrolledWindow::on_scroll_event (GdkEventScroll* event)
             if (value2 != value) {
                 scroll->set_value(value2);
             }
-        } else {
+        } else if (event->direction == GDK_SCROLL_UP) {
             value2 = value - step;
 
             if (value2 < lower) {
@@ -979,6 +979,57 @@ void MyScrolledWindow::get_preferred_height_vfunc (int &minimum_height, int &nat
 void MyScrolledWindow::get_preferred_height_for_width_vfunc (int width, int &minimum_height, int &natural_height) const
 {
     natural_height = minimum_height = 50;
+}
+
+/*
+ *
+ * Derived class of some widgets to properly handle the scroll wheel ;
+ * the user has to use the Shift key to be able to change the widget's value,
+ * otherwise the mouse wheel will scroll the toolbar.
+ *
+ */
+MyScrolledToolbar::MyScrolledToolbar ()
+{
+    set_policy (Gtk::POLICY_EXTERNAL, Gtk::POLICY_NEVER);
+    set_propagate_natural_height(true);
+}
+
+bool MyScrolledToolbar::on_scroll_event (GdkEventScroll* event)
+{
+    Glib::RefPtr<Gtk::Adjustment> adjust = get_hadjustment();
+    Gtk::Scrollbar *scroll = get_hscrollbar();
+
+    if (adjust && scroll) {
+        double upper = adjust->get_upper();
+        double lower = adjust->get_lower();
+        double value = adjust->get_value();
+        double step  = adjust->get_step_increment() * 2;
+        double value2 = 0.;
+
+        if (event->direction == GDK_SCROLL_DOWN) {
+            value2 = value + step;
+
+            if (value2 > upper) {
+                value2 = upper;
+            }
+
+            if (value2 != value) {
+                scroll->set_value(value2);
+            }
+        } else if (event->direction == GDK_SCROLL_UP) {
+            value2 = value - step;
+
+            if (value2 < lower) {
+                value2 = lower;
+            }
+
+            if (value2 != value) {
+                scroll->set_value(value2);
+            }
+        }
+    }
+
+    return true;
 }
 
 MyComboBoxText::MyComboBoxText (bool has_entry) : Gtk::ComboBoxText(has_entry)

--- a/rtgui/guiutils.h
+++ b/rtgui/guiutils.h
@@ -294,6 +294,18 @@ public:
 };
 
 /**
+ * @brief subclass of Gtk::ScrolledWindow in order to handle the large toolbars (wider than available space)
+ */
+class MyScrolledToolbar : public Gtk::ScrolledWindow
+{
+
+    bool on_scroll_event (GdkEventScroll* event);
+
+public:
+    MyScrolledToolbar();
+};
+
+/**
  * @brief subclass of Gtk::ComboBox in order to handle the scrollwheel
  */
 class MyComboBox : public Gtk::ComboBox


### PR DESCRIPTION
...thanks to the new MyScrolledToolbar class (guiutils.h/cc). This is
valid for the FileBrowser tab (first and second line can be scrolled
individually) and the top and bottom bar of the Editor(s) tab.

see #4035